### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@glimmer/vm": "0.76.0",
     "@babel/plugin-transform-parameters": "7.13.0",
     "@babel/plugin-transform-member-expression-literals": "7.12.13",
-    "wrangler": "2.1.7",
+    "wrangler": "3.19.0",
     "@babel/plugin-transform-block-scoping": "7.11.1",
     "@glimmer/runtime": "0.79.2",
     "@glimmer/interfaces": "0.57.2"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "@glimmer/vm": "0.76.0",
     "@babel/plugin-transform-parameters": "7.13.0",
     "@babel/plugin-transform-member-expression-literals": "7.12.13",
-    "wrangler":"2.1.7",
+    "wrangler": "2.1.7",
     "@babel/plugin-transform-block-scoping": "7.11.1",
     "@glimmer/runtime": "0.79.2",
     "@glimmer/interfaces": "0.57.2"
   },
   "devDependencies": {
-    "nodemon": "^2.0.7"
+    "nodemon": "^2.0.7",
+    "undici": "5.28.4"
   }
 }


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| npm:wrangler:2.1.7 | CVE-2023-3348 | Medium  | ### Impact The Wrangler command line tool (<=wrangler@3.1.0<br>or <=wrangler@2.20.1) was affected by a directory traversal<br>vulnerability when running a local development server for<br>Pages (wrangler pages dev command). This vulnerability<br>enabled an attacker in the same network as the victim to<br>connect to the local development server and access the<br>victim's files present outside of the directory for the<br>development server. ### Patches Wrangler2: Upgrade to v2.20.1<br>or higher. Wrangler3: Upgrade to v3.1.1 or higher. ###<br>References [Workers SDK on<br>Github](https://github.com/cloudflare/workers-sdk) [Wrangler<br>docs](https://developers.cloudflare.com/workers/wrangler/)<br>[CVE-2023-3348](https://www.cve.org/CVERecord?id=CVE-2023-3348) |
| npm:wrangler:2.1.7 | CVE-2023-7080 | Critical  | ### Impact The V8 inspector intentionally allows arbitrary<br>code execution within the Workers sandbox for debugging.<br>`wrangler dev` would previously start an inspector server<br>listening on all network interfaces. This would allow an<br>attacker on the local network to connect to the inspector and<br>run arbitrary code. Additionally, the inspector server did<br>not validate `Origin`/`Host` headers, granting an attacker<br>that can trick any user on the local network into opening a<br>malicious website the ability to run code. If `wrangler dev<br>--remote` was being used, an attacker could access production<br>resources if they were bound to the worker. ### Patches This<br>issue was fixed in `wrangler@3.19.0` and `wrangler@2.20.2`.<br>Whilst `wrangler dev`'s inspector server listens on local<br>interfaces by default as of `wrangler@3.16.0`, an [SSRF<br>vulnerability in<br>`miniflare`](https://github.com/cloudflare/workers-sdk/security/advisories/GHSA-fwvg-2739-22v7)<br>allowed access from the local network until<br>`wrangler@3.18.0`. `wrangler@3.19.0` and `wrangler@2.20.2`<br>introduced validation for the `Origin`/`Host` headers. ###<br>Workarounds Unfortunately, Wrangler doesn't provide any<br>configuration for which host that inspector server should<br>listen on. Please upgrade to at least `wrangler@3.16.0`, and<br>configure Wrangler to listen on local interfaces instead with<br>`wrangler dev --ip 127.0.0.1` to prevent SSRF. This removes<br>the local network as an attack vector, but does not prevent<br>an attack from visiting a malicious website. ### References -<br>https://github.com/cloudflare/workers-sdk/issues/4430 -<br>https://github.com/cloudflare/workers-sdk/pull/4437 -<br>https://github.com/cloudflare/workers-sdk/pull/4535 -<br>https://github.com/cloudflare/workers-sdk/pull/4550 |
| npm:undici:5.9.1 | CVE-2024-30261 | Low  | ### Impact If an attacker can alter the `integrity` option<br>passed to `fetch()`, they can let `fetch()` accept requests<br>as valid even if they have been tampered. ### Patches Fixed<br>in<br>https://github.com/nodejs/undici/commit/d542b8cd39ec1ba303f038ea26098c3f355974f3.<br>Fixes has been released in v5.28.4 and v6.11.1. ###<br>Workarounds Ensure that `integrity` cannot be tampered with.<br>### References https://hackerone.com/reports/2377760 |
| npm:undici:5.9.1 | CVE-2024-30260 | Low  | ### Impact Undici cleared Authorization and<br>Proxy-Authorization headers for `fetch()`, but did not clear<br>them for `undici.request()`. ### Patches This has been<br>patched in<br>https://github.com/nodejs/undici/commit/6805746680d27a5369d7fb67bc05f95a28247d75.<br>Fixes has been released in v5.28.4 and v6.11.1. ###<br>Workarounds use `fetch()` or disable `maxRedirections`. ###<br>References Linzi Shang reported this. *<br>https://hackerone.com/reports/2408074 *<br>https://github.com/nodejs/undici/security/advisories/GHSA-3787-6prv-h9w3 |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
