### PR TITLE
📦 Bump npm:wrangler:2.1.7 from 2.1.7 to 2.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@glimmer/vm": "0.76.0",
     "@babel/plugin-transform-parameters": "7.13.0",
     "@babel/plugin-transform-member-expression-literals": "7.12.13",
-    "wrangler":"2.1.7",
+    "wrangler": "3.19.0",
     "@babel/plugin-transform-block-scoping": "7.11.1",
     "@glimmer/runtime": "0.79.2",
     "@glimmer/interfaces": "0.57.2"


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2023-3348 | Medium  | ### Impact The Wrangler command line tool (<=wrangler@3.1.0 or <=wrangler@2.20.1)<br>was affected by a directory traversal vulnerability when running a local<br>development server for Pages (wrangler pages dev command). This vulnerability<br>enabled an attacker in the same network as the victim to connect to the local<br>development server and access the victim's files present outside of the directory<br>for the development server. ### Patches Wrangler2: Upgrade to v2.20.1 or higher.<br>Wrangler3: Upgrade to v3.1.1 or higher. ### References [Workers SDK on<br>Github](https://github.com/cloudflare/workers-sdk) [Wrangler<br>docs](https://developers.cloudflare.com/workers/wrangler/)<br>[CVE-2023-3348](https://www.cve.org/CVERecord?id=CVE-2023-3348) |
| CVE-2023-7080 | Critical  | ### Impact The V8 inspector intentionally allows arbitrary code execution within<br>the Workers sandbox for debugging. `wrangler dev` would previously start an<br>inspector server listening on all network interfaces. This would allow an<br>attacker on the local network to connect to the inspector and run arbitrary code.<br>Additionally, the inspector server did not validate `Origin`/`Host` headers,<br>granting an attacker that can trick any user on the local network into opening a<br>malicious website the ability to run code. If `wrangler dev --remote` was being<br>used, an attacker could access production resources if they were bound to the<br>worker. ### Patches This issue was fixed in `wrangler@3.19.0` and<br>`wrangler@2.20.2`. Whilst `wrangler dev`'s inspector server listens on local<br>interfaces by default as of `wrangler@3.16.0`, an [SSRF vulnerability in<br>`miniflare`](https://github.com/cloudflare/workers-sdk/security/advisories/GHSA-fwvg-2739-22v7)<br>allowed access from the local network until `wrangler@3.18.0`. `wrangler@3.19.0`<br>and `wrangler@2.20.2` introduced validation for the `Origin`/`Host` headers. ###<br>Workarounds Unfortunately, Wrangler doesn't provide any configuration for which<br>host that inspector server should listen on. Please upgrade to at least<br>`wrangler@3.16.0`, and configure Wrangler to listen on local interfaces instead<br>with `wrangler dev --ip 127.0.0.1` to prevent SSRF. This removes the local<br>network as an attack vector, but does not prevent an attack from visiting a<br>malicious website. ### References -<br>https://github.com/cloudflare/workers-sdk/issues/4430 -<br>https://github.com/cloudflare/workers-sdk/pull/4437 -<br>https://github.com/cloudflare/workers-sdk/pull/4535 -<br>https://github.com/cloudflare/workers-sdk/pull/4550 |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
